### PR TITLE
docs: simplify install instructions and Claude Code support

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -7,10 +7,7 @@
     "url": "https://github.com/Fokkyp"
   },
   "homepage": "https://github.com/Fokkyp/SoftwareCopyright-Skill",
-  "repository": {
-    "type": "git",
-    "url": "https://github.com/Fokkyp/SoftwareCopyright-Skill"
-  },
+  "repository": "https://github.com/Fokkyp/SoftwareCopyright-Skill",
   "license": "MIT",
   "keywords": ["software-copyright", "chinese-copyright", "docx", "软著", "著作权"]
 }

--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Software Copyright Materials Skill
 
-这是一个用于生成中文软件著作权申请资料的 Codex Skill 开源仓库。
+这是一个用于生成中文软件著作权申请资料的 Skill / 插件仓库，可用于 Codex，也可作为 Claude Code 插件加载。
 
 项目地址：https://github.com/Fokkyp/SoftwareCopyright-Skill
 
@@ -10,7 +10,7 @@
 software-copyright-materials/
 ```
 
-安装时应将 `software-copyright-materials/` 目录复制或安装到用户的 Codex skills 目录中，而不是把本仓库根目录整体作为一个 skill。
+安装时不要把仓库根目录当作普通单个 skill 复制。Codex 使用 `software-copyright-materials/` 这个实际 skill 目录；Claude Code 使用仓库根目录中的 `.claude-plugin/plugin.json` 和 `skills/` 插件结构。
 
 ## 功能概览
 
@@ -18,7 +18,7 @@ software-copyright-materials/
 
 软件著作权申请本身不神秘，真正麻烦的是整理材料：申请表字段要写对，操作手册要像样，代码材料要按规则截取，软件名称、版本号、页数还要保持一致。很多开发者最后会把这件事交给付费代办或资料整理服务，花钱买的往往也只是这些文档整理工作。
 
-这个 skill 的目标很直接：让开发者不用再为整理软著材料额外付费，也不用把项目代码和产品细节交给外部商家来回沟通。把真实项目交给 Codex，它会按流程引导你确认关键信息，并在本地生成一整套可检查、可修改、可提交前再导出的软著申请资料。
+这个 skill 的目标很直接：让开发者不用再为整理软著材料额外付费，也不用把项目代码和产品细节交给外部商家来回沟通。把真实项目交给支持该 skill 的代码助手，它会按流程引导你确认关键信息，并在本地生成一整套可检查、可修改、可提交前再导出的软著申请资料。
 
 - **自己生成整套资料**：从项目分析、业务理解、申请表信息、操作手册到代码材料，一套流程跑完，不再依赖外部代办整理文档。
 - **从真实源码抽取代码**：代码材料只来自开发者已有项目，禁止 AI 编造源码，适合对材料真实性敏感的开发者。
@@ -69,59 +69,84 @@ software-copyright-materials/
 
 ## 下载并安装
 
-推荐按下面顺序操作。
-
-### 第一步：下载代码
-
-会用 Git 的用户执行：
+先获取本仓库。会用 Git 的用户执行：
 
 ```bash
 git clone https://github.com/Fokkyp/SoftwareCopyright-Skill.git
 cd SoftwareCopyright-Skill
 ```
 
-不会用 Git 的用户：
-
-打开 GitHub 仓库页面，点击 `Code`，再点击 `Download ZIP`。下载后解压，进入解压出来的目录。
-
-进入目录后，应能看到这个文件夹：
+不会用 Git 的用户可以在 GitHub 页面点击 `Code` -> `Download ZIP`，解压后进入仓库目录。目录中应能看到：
 
 ```text
 software-copyright-materials/
+.claude-plugin/plugin.json
+skills/software-copyright-materials
 ```
 
-### 第二步：安装到 Codex
+按使用工具选择一种方式：
 
-把 `software-copyright-materials/` 复制到 Codex 的 skills 目录：
+**Codex**：复制实际 skill 目录。
 
 ```bash
 mkdir -p ~/.codex/skills
 cp -R software-copyright-materials ~/.codex/skills/
 ```
 
-安装完成后，应看到：
+**Claude Code**：把本仓库作为插件目录加载。
 
-```text
-~/.codex/skills/software-copyright-materials/SKILL.md
+```bash
+claude --plugin-dir /path/to/SoftwareCopyright-Skill
 ```
 
-### 第三步：重启 Codex
+在本仓库目录中可以直接执行：
 
-重新打开 Codex 会话或刷新技能列表，然后在项目中提出“生成软著申请资料”等请求即可使用。
+```bash
+claude --plugin-dir .
+```
+
+Claude Code 手动调用时使用插件命名空间：
+
+```text
+/software-copyright-materials:software-copyright-materials
+```
+
+如果只想在某个项目里使用，Codex 可复制到该项目的 `.codex/skills/`：
+
+```bash
+PROJECT_DIR="<你的项目目录>"
+mkdir -p "$PROJECT_DIR/.codex/skills"
+cp -R software-copyright-materials "$PROJECT_DIR/.codex/skills/"
+```
+
+Claude Code 可在目标项目目录启动时指定本仓库：
+
+```bash
+cd "<你的项目目录>"
+claude --plugin-dir "<SoftwareCopyright-Skill 仓库路径>"
+```
+
+修改 README 或 skill 后，重启会话，或在 Claude Code 中执行 `/reload-plugins` 重新加载。
 
 ## 运行要求和环境校验
 
 ### 必需环境
 
-- **Codex**：本仓库提供的是 Codex Skill，需要在 Codex 中使用。
-- **Python 3**：生成流程依赖 `software-copyright-materials/scripts/` 下的 Python 脚本，用于分析项目、生成草稿、抽取真实代码、校验字段和生成正式资料。
-- **可读取的项目源码**：代码材料必须从真实项目中抽取，所以需要在 Codex 中打开或指定你的项目目录。
+- **支持 Skill / Plugin 的代码助手**：Codex 可按 skill 目录加载；Claude Code 可按插件目录加载。
+- **Python 3.10+ 和 python-docx**：生成流程依赖 `software-copyright-materials/scripts/` 下的 Python 脚本，用于分析项目、生成草稿、抽取真实代码、校验字段和生成正式资料。
+- **可读取的项目源码**：代码材料必须从真实项目中抽取，所以需要在代码助手中打开或指定你的项目目录。
+
+安装 Python 依赖：
+
+```bash
+python3 -m pip install python-docx
+```
 
 ### 可选环境
 
-- **.NET SDK**：用于启用更完整的 DOCX OpenXML 生成和校验能力。没有 .NET SDK 也可以继续使用基础 DOCX 兜底生成。
+- **.NET SDK 8.0+**：用于启用更完整的 DOCX OpenXML 生成和校验能力。没有 .NET SDK 也可以继续使用基础 DOCX 兜底生成。
 - **Chrome DevTools MCP**：只有在你希望自动截取网页截图时才需要。
-- **Codex Computer Use**：只有在你希望通过桌面界面操作并截图时才需要。
+- **Codex Computer Use**：仅 Codex 环境需要桌面界面操作和截图时使用。
 - **用户自行截图**：如果没有 MCP 或 Computer Use，也可以手动把截图放到指定目录，或者直接跳过截图。
 
 ### 使用过程中会自动检查吗？
@@ -140,36 +165,28 @@ cp -R software-copyright-materials ~/.codex/skills/
 - `.NET SDK` 是否缺失。
 - 当前会把材料生成到哪里。
 
-如果完整 DOCX 环境缺失，Codex 会停下来让你选择：
+如果完整 DOCX 环境缺失，代码助手会停下来让你选择：
 
 1. 安装完整 DOCX 环境。
 2. 使用基础 DOCX 兜底继续。
 
 它不会在你不确认的情况下静默安装依赖。截图也一样，会先让你选择 Chrome DevTools MCP、Codex Computer Use、用户自行截图或跳过截图；如果你跳过截图，操作手册里会保留可见的截图预留位置。
 
-### 安装到某个项目内
-
-如果只想让某个项目使用这个 skill，在你希望下载本仓库的目录执行下面这一行命令。把 `<你的项目目录>` 替换成真实项目路径：
-
-```bash
-PROJECT_DIR="<你的项目目录>" && git clone https://github.com/Fokkyp/SoftwareCopyright-Skill.git && mkdir -p "$PROJECT_DIR/.codex/skills" && cp -R SoftwareCopyright-Skill/software-copyright-materials "$PROJECT_DIR/.codex/skills/"
-```
-
-安装后应为：
-
-```text
-<你的项目目录>/.codex/skills/software-copyright-materials/SKILL.md
-```
-
 ## 基本使用
 
-安装完成后，在 Codex 中打开需要生成软著资料的项目，然后直接说：
+安装或加载完成后，在代码助手中打开需要生成软著资料的项目，然后直接说：
 
 ```text
 使用 software-copyright-materials 生成当前项目的软件著作权申请资料
 ```
 
-Codex 会按流程引导填写信息、确认草稿，并在当前项目目录下生成 `软件著作权申请资料/`。
+在 Claude Code 中也可以手动调用：
+
+```text
+/software-copyright-materials:software-copyright-materials 读取当前目录中的项目，生成软件著作权申请资料草稿
+```
+
+代码助手会按流程引导填写信息、确认草稿，并在当前项目目录下生成 `软件著作权申请资料/`。
 
 ## 开源协议
 


### PR DESCRIPTION
这版补充 #12 合并后的说明文档收尾：

- 将 README 开头和运行要求从 Codex-only 改为 Codex / Claude Code 通用口径。
- 精简“下载并安装”章节，保留 Git / ZIP 获取方式，并按 Codex 与 Claude Code 分别给出最短安装或加载命令。
- 说明 Claude Code 的插件命名空间调用方式，以及项目内使用方式。
- 修正 .claude-plugin/plugin.json 的 repository 字段类型，使当前 Claude Code CLI 校验通过。

验证：
- git diff --check
- claude plugin validate .